### PR TITLE
Fix mismatched labels for player_died counter

### DIFF
--- a/images/metrics-exporter/programs/player.mtail
+++ b/images/metrics-exporter/programs/player.mtail
@@ -29,7 +29,7 @@ gauge player_steamid_by_nick by player_nick
 gauge player_character by steam_id, player_id, player_nick
 gauge player_game_version by steam_id, version
 
-counter player_died by player_nick, steam_id
+counter player_died by steam_id, player_nick
 
 counter player_disconnected_count by steam_id
 gauge player_disconnected_last by steam_id


### PR DESCRIPTION
The labels for `nick` and `steam_id` are mismatched in the `player_died` counter under `player.mtail`. 

Example (steam_id's redacted):

\# HELP player_died defined at player.mtail:32:9-19
\# TYPE player_died counter
player_died{player_nick="7656119##########",prog="player.mtail",steam_id="JoeCool97"} 1
player_died{player_nick="7656119##########",prog="player.mtail",steam_id="BigSam23"} 9